### PR TITLE
Fix font and color default input

### DIFF
--- a/_src/templates/partials/_custom.html
+++ b/_src/templates/partials/_custom.html
@@ -26,7 +26,7 @@
                 <div class="box_greenhospital"></div>
               </div>
             </label>
-            <input id="setcolors_green" type="radio" name="setcolors_option">
+            <input id="setcolors_green" type="radio" name="setcolors_option" checked="true">
           </li>
           <li class="color_container">
             <label class="list_item" for="setcolors_red">
@@ -60,7 +60,7 @@
             </li>
             <li class="fonts_position">
               <label class="list_item" for="ComicSans">Comic Sans</label>
-              <input class="selector_position" id="ComicSans" type="radio" name="fonts_option">
+              <input class="selector_position" id="ComicSans" type="radio" name="fonts_option" checked="true">
             </li>
             <li class="fonts_position">
               <label class="list_item" for="Montserrat">Montserrat</label>


### PR DESCRIPTION
Hey @inmasalcedo ! I fixed the default input in the fonts and colors selectors. I just had to add `checked="true"` in the inputs that needed to be default. Can you check the changes? :)